### PR TITLE
Add legacy-cgi for python >=3.13

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 35a7da36a5ff61e69a7f2321dff40c6c20282749c1e43564db86dbc8324d6bbf
 
 build:
-  number: 4
+  number: 5
   noarch: python
   script: ${{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -27,6 +27,7 @@ requirements:
     - numba >=0.59.1
     - scipy >=1.10.0,<2.0.0
     - packaging >=21.3
+    - legacy-cgi
 
 tests:
   - python:


### PR DESCRIPTION
Cgi is used by `interpolation` but was removed from the standard library in Python 3.13.

The legacy-cgi package is a polyfill for it. On conda-forge, the package is empty for Python <3.13.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
